### PR TITLE
fix: broken Google profile avatar in navbar

### DIFF
--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -8,12 +8,12 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: "html",
   use: {
-    baseURL: "http://localhost:5173",
+    baseURL: "http://localhost:5174",
     trace: "on-first-retry",
   },
   webServer: {
     command: "npm run dev",
-    url: "http://localhost:5173",
+    url: "http://localhost:5174",
     reuseExistingServer: !process.env.CI,
   },
 });

--- a/client/src/components/layout/Navbar.tsx
+++ b/client/src/components/layout/Navbar.tsx
@@ -38,6 +38,7 @@ export function Navbar() {
                     src={user.avatarUrl}
                     alt=""
                     className="w-8 h-8 rounded-full"
+                    referrerPolicy="no-referrer"
                   />
                 )}
                 <span className="text-sm text-gray-700">

--- a/client/tests/e2e/navbar.spec.ts
+++ b/client/tests/e2e/navbar.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Navbar", () => {
+  test.beforeEach(async ({ page }) => {
+    // Simulate an authenticated user with a Google avatar URL
+    await page.route("**/api/auth/me", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          user: {
+            id: "test-user",
+            email: "test@example.com",
+            name: "Davy De Waele",
+            avatarUrl:
+              "https://lh3.googleusercontent.com/a/test-avatar=s96-c",
+            createdAt: new Date().toISOString(),
+          },
+        }),
+      });
+    });
+
+    await page.goto("/");
+  });
+
+  test("avatar img has referrerPolicy=no-referrer to prevent broken image on Google CDN", async ({
+    page,
+  }) => {
+    const avatar = page.locator("img.rounded-full").first();
+    await expect(avatar).toBeVisible();
+    await expect(avatar).toHaveAttribute("referrerpolicy", "no-referrer");
+  });
+
+  test("avatar img src points to the user avatarUrl", async ({ page }) => {
+    const avatar = page.locator("img.rounded-full").first();
+    await expect(avatar).toHaveAttribute(
+      "src",
+      "https://lh3.googleusercontent.com/a/test-avatar=s96-c",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes #3
- Google profile pictures from `lh3.googleusercontent.com` fail to load because browsers strip the `Referer` header on cross-origin requests by default
- Adding `referrerPolicy="no-referrer"` on the `<img>` tag suppresses the header, which is what Google's CDN expects
- Also corrects Playwright `baseURL` / `webServer.url` from port 5173 → 5174 (was preventing E2E tests from running)

## Change

```tsx
// Navbar.tsx — before
<img src={user.avatarUrl} alt="" className="w-8 h-8 rounded-full" />

// after
<img src={user.avatarUrl} alt="" className="w-8 h-8 rounded-full" referrerPolicy="no-referrer" />
```

## Tests

Added `client/tests/e2e/navbar.spec.ts`:

- ✅ Avatar `<img>` has `referrerpolicy="no-referrer"` attribute
- ✅ Avatar `src` matches the user's `avatarUrl`

## Test plan

- [ ] Run `npm run test:e2e` in `client/` — all 8 tests pass
- [ ] Log in with Google OAuth — avatar appears correctly next to the user's name in the navbar