### PR TITLE
Fix missing Prisma migrations for Quiz schema columns

### DIFF
--- a/server/prisma/migrations/20260322000000_add_missing_quiz_columns/migration.sql
+++ b/server/prisma/migrations/20260322000000_add_missing_quiz_columns/migration.sql
@@ -1,0 +1,9 @@
+-- Add columns that were added via prisma db push but never had migration files
+
+ALTER TABLE "Quiz" ADD COLUMN IF NOT EXISTS "subject" TEXT;
+ALTER TABLE "Quiz" ADD COLUMN IF NOT EXISTS "metaVersion" TEXT;
+ALTER TABLE "Quiz" ADD COLUMN IF NOT EXISTS "metaCreated" TEXT;
+
+ALTER TABLE "QuizQuestion" ADD COLUMN IF NOT EXISTS "difficulty" TEXT;
+ALTER TABLE "QuizQuestion" ADD COLUMN IF NOT EXISTS "topic" TEXT;
+ALTER TABLE "QuizQuestion" ADD COLUMN IF NOT EXISTS "tags" JSONB;


### PR DESCRIPTION
Closes #17

## Summary

- Added migration for `subject`, `metaVersion`, `metaCreated` columns on `Quiz` table
- Added migration for `difficulty`, `topic`, `tags` columns on `QuizQuestion` table
- Uses `IF NOT EXISTS` so it's safe to run against existing local databases
- Fixes Railway deployment failure: `P2022: The column Quiz.subject does not exist`

## Test plan

- [x] 24 E2E tests passing locally
- [ ] Railway deployment succeeds and healthcheck passes after merge